### PR TITLE
Implement file type detection

### DIFF
--- a/ftdetect/ragelfiletype.vim
+++ b/ftdetect/ragelfiletype.vim
@@ -1,0 +1,7 @@
+" Make sure we set the filetype when we open a Ragel file.
+augroup vim-ragel-filetype
+  autocmd!
+  au BufRead,BufNewFile *.rl,*.ragel set filetype=ragel
+augroup END
+
+" vim: sw=2 ts=2 et


### PR DESCRIPTION
This PR implements file type detection so that Ragel files that are opened in VIM actually use the syntax highlighting.

Tested in NeoVim.